### PR TITLE
docs: add Ko-fi sponsorship details

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: nanako0129

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ interactive option. Exiting the child session removes every override.
 - [Isolation and security](#isolation-and-security)
 - [Troubleshooting](#troubleshooting)
 - [Uninstall](#uninstall)
+- [Support remora](#support-remora)
 - [Further reading](#further-reading)
 
 ## What remora changes
@@ -262,6 +263,22 @@ Claude Code. For file-level evidence, compare a SHA-256 manifest of
 
 The default keeps `config.toml`; `--purge` removes it. Neither command touches
 `~/.claude`.
+
+## Support remora
+
+remora is a small, free launcher, but verifying its isolation and routing
+promises crosses Claude Code, an Anthropic-compatible gateway, GPT-5.6 model
+routes, OAuth and subscription quota behavior, changing context metadata, and
+optional priority-tier requests.
+
+The public
+[Baton compatibility Gate](./benchmarks/baton-compatibility/README.md#final-gate-result)
+alone used 45 model turns and reported $2.15 in client-reported cost; a
+rejected candidate consumed more before it was discarded. Sponsorship helps
+fund the live model credits and repeated multi-agent and independent-verifier
+runs needed to keep these guarantees evidence-based instead of assumed.
+
+[![Support remora on Ko-fi](https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/nanako0129)
 
 ## Further reading
 


### PR DESCRIPTION
## Summary

- add `.github/FUNDING.yml` for the `nanako0129` Ko-fi page
- add a project-specific README section connecting sponsorship to remora's documented live integration costs

## Why

remora is a small launcher, but its isolation and routing promises cross Claude Code, an Anthropic-compatible gateway, model routes, quota behavior, context metadata, optional priority-tier requests, and independent verification. The README now explains those costs and cites the public compatibility Gate.

## Scope

This changes documentation and GitHub funding metadata only. Launcher behavior, gateway configuration, role routing, isolation, and release packaging remain unchanged.

## Verification

- `make check` — passed, including 82 Python tests and install/bootstrap checks
- `git diff --check origin/main...HEAD` — passed
- confirmed the commit contains only `README.md` and `.github/FUNDING.yml`
- no live gateway or paid model test was run for this documentation-only change

## Automation disclosure

This documentation change was authored with Codex assistance. The final diff, repository checks, cited evidence, and commit scope were independently checked locally.