### PR TITLE
chore: switch funding link to Patreon

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-ko_fi: nanako0129
+custom: ["https://www.patreon.com/cw/Nanako0129/membership"]

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ rejected candidate consumed more before it was discarded. Sponsorship helps
 fund the live model credits and repeated multi-agent and independent-verifier
 runs needed to keep these guarantees evidence-based instead of assumed.
 
-[![Support remora on Ko-fi](https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/nanako0129)
+[![Support remora on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 
 ## Further reading
 


### PR DESCRIPTION
## Summary

- replace the Ko-fi funding entry with the Patreon membership page
- keep the GitHub Sponsor sidebar pointed at the current support channel

## Verification

- `git diff --check`
- confirmed the Patreon membership URL returns HTTP 200