### PR TITLE
fix(agents): route security executor at xhigh

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ the gateway owns protocol translation, OAuth, retries, cooldown, and billing.
 | `mech-executor` | `gpt-5.6-luna` | medium | Mechanical implementation |
 | `executor` | `gpt-5.6-luna` | max | Judgment-heavy implementation |
 | `verifier` | `gpt-5.6-sol` | high | Adversarial outcome verification |
-| `security-executor` | `gpt-5.6-sol` | max | Approved security implementation |
+| `security-executor` | `gpt-5.6-sol` | xhigh | Approved security implementation |
 
 | Context mode | Claude binary | Client window | Use when |
 | --- | --- | ---: | --- |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -79,7 +79,7 @@ translation、OAuth、retry、cooldown 與 billing 都由 gateway 負責。
 | `mech-executor` | `gpt-5.6-luna` | medium | 機械式實作 |
 | `executor` | `gpt-5.6-luna` | max | 需要判斷的實作 |
 | `verifier` | `gpt-5.6-sol` | high | 對抗式結果驗證 |
-| `security-executor` | `gpt-5.6-sol` | max | 已批准的安全實作 |
+| `security-executor` | `gpt-5.6-sol` | xhigh | 已批准的安全實作 |
 
 | Context 模式 | Claude binary | Client window | 使用時機 |
 | --- | --- | ---: | --- |

--- a/config.example.toml
+++ b/config.example.toml
@@ -47,7 +47,7 @@ security-reviewer = "high"
 mech-executor = "medium"
 executor = "max"
 verifier = "high"
-security-executor = "max"
+security-executor = "xhigh"
 
 [runtime]
 claude_binary = "claude"

--- a/tests/test_remora.py
+++ b/tests/test_remora.py
@@ -57,6 +57,10 @@ class RemoraTests(unittest.TestCase):
         self.assertEqual(agents["executor"]["model"], "gpt-5.6-luna")
         self.assertEqual(agents["executor"]["effort"], "max")
         self.assertEqual(agents["verifier"]["effort"], "high")
+        self.assertEqual(
+            (agents["security-executor"]["model"], agents["security-executor"]["effort"]),
+            ("gpt-5.6-sol", "xhigh"),
+        )
         self.assertIn("Agent", agents["executor"]["disallowedTools"])
 
     @mock.patch.dict(os.environ, {"REMORA_AUTH_TOKEN": "test-secret", "CLAUDE_CODE_SUBAGENT_MODEL": "wrong"}, clear=False)


### PR DESCRIPTION
## Summary

- keep `security-executor` on `gpt-5.6-sol` and change its default effort from `max` to `xhigh`
- update the English and Traditional Chinese role tables
- bind the model and effort pair in the existing role-map contract test

## Why

[OpenAI's current Security scan guidance](https://learn.chatgpt.com/docs/security/plugin/scans#configure-the-scan) recommends Sol at `xhigh`. This keeps the security-specific model route while avoiding `max` as the unqualified default. It does not claim that reasoning effort caused a specific incident.

## Impact

New configurations generated from `config.example.toml` render the security executor as Sol/`xhigh`. Existing user config is preserved by the installer and will not be silently rewritten. Runtime code, role capabilities, versioning, packaging, and release behavior are unchanged.

## Checks

- focused role-map unittest: passed
- `make check`: 83 tests plus install, bootstrap, compile, shell syntax, agent render, and dry-run checks passed
- `git diff --check`: passed
- pre-implementation security review: no P0-P2 findings
- fresh outcome verifier: `CONFIRMED`

## Evidence boundary

This PR proves the static default and rendered role contract. It does not include a live security-executor invocation or claim incident containment.
