### PR TITLE
feat(context): use GPT-5.6 maximum windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Runtime behavior and reference documents:
 | Caller settings | Recursively merged; remora-owned keys remain authoritative | [Isolation contract](./docs/architecture.md#isolation-contract) |
 | Fallback | `fallbackModel: []`; CLI `--fallback-model` is rejected | [Isolation contract](./docs/architecture.md#isolation-contract) |
 | Wrapper prompts | `REMORA_COMPOSE_SYSTEM_PROMPT=1` composes caller then remora policy | [Role policy](./docs/architecture.md#role-policy) |
-| Context and Calico | Fails closed on stale or inconsistent metadata | [Gateway semantics](./docs/architecture.md#gateway-semantics) |
+| Context and Calico | Fails closed on stale or inconsistent metadata | [CLIProxyAPI context runbook](./docs/cliproxyapi.md#context-window-alignment) |
 | Compact hardening | remora marks `REMORA_ACTIVE` only; Calico body policy + gateway class guard | [Compact request hardening](./docs/cliproxyapi.md#compact-request-hardening-calico--gateway) |
 | Active-turn bridge | Experimental and topology-limited | [Gateway runbook](./docs/cliproxyapi.md#experimental-active-turn-bridge) |
 
@@ -195,6 +195,34 @@ The environment variable wins when present. Otherwise remora executes the
 credential command directly without a shell. Existing pre-eight-role configs
 remain compatible; use [`config.example.toml`](./config.example.toml) to add
 independent Plan and security reviewer routing.
+
+### GPT-5.6 family long context through CLIProxyAPI
+
+For native Codex CLI sessions using the CLIProxyAPI Codex OAuth route, add this
+to `~/.codex/config.toml`:
+
+```toml
+model = "gpt-5.6-sol" # Or gpt-5.6-terra / gpt-5.6-luna.
+model_context_window = 921000
+model_auto_compact_token_limit = 828900
+# Optional; `total` is the default.
+model_auto_compact_token_limit_scope = "total"
+```
+
+| Profile file | Model | Run with |
+| --- | --- | --- |
+| `$CODEX_HOME/sol.config.toml` | `gpt-5.6-sol` | `codex --profile sol` |
+| `$CODEX_HOME/terra.config.toml` | `gpt-5.6-terra` | `codex --profile terra` |
+| `$CODEX_HOME/luna.config.toml` | `gpt-5.6-luna` | `codex --profile luna` |
+
+Each profile contains the same three context/compact keys shown above, with its
+row's model pinned.
+
+All three GPT-5.6 slugs accepted reported `input_tokens=921,858`; the adjacent
+`921,859` was rejected. This changes native Codex client accounting and
+auto-compaction only, not OAuth entitlement or gateway configuration. CLIProxyAPI
+needs no YAML context edit or restart. See the
+[CLIProxyAPI context runbook](./docs/cliproxyapi.md#context-window-alignment).
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -196,32 +196,14 @@ credential command directly without a shell. Existing pre-eight-role configs
 remain compatible; use [`config.example.toml`](./config.example.toml) to add
 independent Plan and security reviewer routing.
 
-### GPT-5.6 family long context through CLIProxyAPI
+### GPT-5.6 family context discovery
 
-For native Codex CLI sessions using the CLIProxyAPI Codex OAuth route, add this
-to `~/.codex/config.toml`:
-
-```toml
-model = "gpt-5.6-sol" # Or gpt-5.6-terra / gpt-5.6-luna.
-model_context_window = 921000
-model_auto_compact_token_limit = 828900
-# Optional; `total` is the default.
-model_auto_compact_token_limit_scope = "total"
-```
-
-| Profile file | Model | Run with |
-| --- | --- | --- |
-| `$CODEX_HOME/sol.config.toml` | `gpt-5.6-sol` | `codex --profile sol` |
-| `$CODEX_HOME/terra.config.toml` | `gpt-5.6-terra` | `codex --profile terra` |
-| `$CODEX_HOME/luna.config.toml` | `gpt-5.6-luna` | `codex --profile luna` |
-
-Each profile contains the same three context/compact keys shown above, with its
-row's model pinned.
-
-All three GPT-5.6 slugs accepted reported `input_tokens=921,858`; the adjacent
-`921,859` was rejected. This changes native Codex client accounting and
-auto-compaction only, not OAuth entitlement or gateway configuration. CLIProxyAPI
-needs no YAML context edit or restart. See the
+In `calico` mode, Remora reads gateway and fresh Codex model metadata without
+writing native Codex or CLIProxyAPI configuration. For the exact GPT-5.6 family
+slugs it prefers a valid `max_context_window`, safely falls back to existing
+context fields, takes the smaller gateway/runtime value, and derives the 90%
+compact trigger. When both sources advertise 921,000, all three compact at
+828,900. See the
 [CLIProxyAPI context runbook](./docs/cliproxyapi.md#context-window-alignment).
 
 ## Use

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -189,31 +189,14 @@ auth_token_command = [
 八角色版本之前建立的設定仍可使用；需要獨立控制 Plan 與 security reviewer
 時，依 [`config.example.toml`](./config.example.toml) 補上欄位。
 
-### CLIProxyAPI 上的 GPT-5.6 family 長 context
+### CLIProxyAPI 上的 GPT-5.6 family context discovery
 
-原生 Codex CLI 透過 CLIProxyAPI Codex OAuth route 時，在
-`~/.codex/config.toml` 加入：
-
-```toml
-model = "gpt-5.6-sol" # Or gpt-5.6-terra / gpt-5.6-luna.
-model_context_window = 921000
-model_auto_compact_token_limit = 828900
-# Optional；`total` 是預設值。
-model_auto_compact_token_limit_scope = "total"
-```
-
-| Profile 檔案 | Model | 啟動方式 |
-| --- | --- | --- |
-| `$CODEX_HOME/sol.config.toml` | `gpt-5.6-sol` | `codex --profile sol` |
-| `$CODEX_HOME/terra.config.toml` | `gpt-5.6-terra` | `codex --profile terra` |
-| `$CODEX_HOME/luna.config.toml` | `gpt-5.6-luna` | `codex --profile luna` |
-
-每個 profile 都包含上方相同的三個 context／compact keys，並固定該列的 model。
-
-三個 GPT-5.6 slug 都接受回報的 `input_tokens=921,858`；緊鄰的 `921,859`
-被拒絕。這只改變原生 Codex client accounting 與 auto-compaction，不改變
-OAuth entitlement 或 gateway 設定。CLIProxyAPI 不需要修改 context YAML 或
-重啟。詳見 [CLIProxyAPI context runbook](./docs/cliproxyapi.zh-TW.md#context-window-對齊)。
+在 `calico` 模式，Remora 只讀 gateway 與新鮮的 Codex model metadata，不會寫入
+原生 Codex 或 CLIProxyAPI 設定。對精確的 GPT-5.6 family slug，優先採用有效的
+`max_context_window`，無效時安全回退到既有 context 欄位，再取 gateway／runtime
+較小值並推導 90% compact trigger。兩個來源都宣告 921,000 時，三者都會在
+828,900 compact。詳見
+[CLIProxyAPI context runbook](./docs/cliproxyapi.zh-TW.md#context-window-對齊)。
 
 ## 使用
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -101,7 +101,7 @@ Runtime 行為與參考文件：
 | Caller settings | 遞迴合併；remora-owned keys 保持 authoritative | [Isolation contract](./docs/architecture.md#isolation-contract) |
 | Fallback | 注入 `fallbackModel: []`；拒絕 CLI `--fallback-model` | [Isolation contract](./docs/architecture.md#isolation-contract) |
 | Wrapper prompts | `REMORA_COMPOSE_SYSTEM_PROMPT=1` 依序合成 caller 與 remora policy | [Role policy](./docs/architecture.md#role-policy) |
-| Context 與 Calico | Metadata 過期或不一致時 fail closed | [Gateway semantics](./docs/architecture.md#gateway-semantics) |
+| Context 與 Calico | Metadata 過期或不一致時 fail closed | [CLIProxyAPI context runbook](./docs/cliproxyapi.zh-TW.md#context-window-對齊) |
 | Compact 硬化 | remora 只標 `REMORA_ACTIVE`；body 歸 Calico、class guard 歸 gateway | [Compact 請求硬化](./docs/cliproxyapi.zh-TW.md#compact-請求硬化calico--gateway) |
 | Active-turn bridge | 實驗性功能，只支援有限 topology | [Gateway runbook](./docs/cliproxyapi.zh-TW.md#實驗性-active-turn-bridge) |
 
@@ -188,6 +188,32 @@ auth_token_command = [
 環境變數存在時優先；否則 remora 不經 shell，直接執行 credential command。
 八角色版本之前建立的設定仍可使用；需要獨立控制 Plan 與 security reviewer
 時，依 [`config.example.toml`](./config.example.toml) 補上欄位。
+
+### CLIProxyAPI 上的 GPT-5.6 family 長 context
+
+原生 Codex CLI 透過 CLIProxyAPI Codex OAuth route 時，在
+`~/.codex/config.toml` 加入：
+
+```toml
+model = "gpt-5.6-sol" # Or gpt-5.6-terra / gpt-5.6-luna.
+model_context_window = 921000
+model_auto_compact_token_limit = 828900
+# Optional；`total` 是預設值。
+model_auto_compact_token_limit_scope = "total"
+```
+
+| Profile 檔案 | Model | 啟動方式 |
+| --- | --- | --- |
+| `$CODEX_HOME/sol.config.toml` | `gpt-5.6-sol` | `codex --profile sol` |
+| `$CODEX_HOME/terra.config.toml` | `gpt-5.6-terra` | `codex --profile terra` |
+| `$CODEX_HOME/luna.config.toml` | `gpt-5.6-luna` | `codex --profile luna` |
+
+每個 profile 都包含上方相同的三個 context／compact keys，並固定該列的 model。
+
+三個 GPT-5.6 slug 都接受回報的 `input_tokens=921,858`；緊鄰的 `921,859`
+被拒絕。這只改變原生 Codex client accounting 與 auto-compaction，不改變
+OAuth entitlement 或 gateway 設定。CLIProxyAPI 不需要修改 context YAML 或
+重啟。詳見 [CLIProxyAPI context runbook](./docs/cliproxyapi.zh-TW.md#context-window-對齊)。
 
 ## 使用
 

--- a/docs/cliproxyapi.md
+++ b/docs/cliproxyapi.md
@@ -206,7 +206,13 @@ remora dry-run
 
 ## Context-window alignment
 
-Do not copy the public OpenAI API context number into CLIProxyAPI metadata. The public GPT-5.6 API documents 1.05M, while CLIProxyAPI currently reports 372K for the Codex OAuth route. That gateway value is only one ceiling: an authoritative Codex runtime-catalog hot update changed Sol, Terra, and Luna to 272K on 2026-07-13.
+Do not copy the public OpenAI API context number into CLIProxyAPI metadata. The
+official [GPT-5.6-sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol),
+[GPT-5.6-terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra), and
+[GPT-5.6-luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna) docs
+each state 1,050,000 total context and 128,000 maximum output. In the live
+CLIProxyAPI catalog on 2026-08-17, all three returned `context_window: 272000`,
+`max_context_window: 921000`, and `auto_compact_token_limit: null`.
 
 Stock CLIProxyAPI exposes that value without any server modification:
 
@@ -214,12 +220,55 @@ Stock CLIProxyAPI exposes that value without any server modification:
 curl -fsS \
   -H "Authorization: Bearer $REMORA_AUTH_TOKEN" \
   'http://127.0.0.1:8317/v1/models?client_version=remora' \
-  | jq '.models[] | select(.slug | startswith("gpt-5.6-")) | {slug, context_window}'
+  | jq '.models[] | select(.slug | test("^gpt-5\\.6-(sol|terra|luna)$")) | {slug, context_window, max_context_window, auto_compact_token_limit}'
+```
+
+Direct `/v1/responses` probes through the Codex OAuth upstream for each slug
+accepted reported `usage.input_tokens=921,858`; the adjacent `921,859` returned
+`invalid_request_error` with code `context_too_large`. Payload calibration
+measured fixed 302-token translated overhead, so repeated-input counts were
+921,556 versus 921,557. On Luna, `max_output_tokens` values 16, 17, 128, 1000,
+and 128000 all accepted at reported input 921,858, so that parameter did not
+move the observed boundary. The official 1.05M total and 128K maximum-output
+facts are consistent context, but do not independently establish this exact
+OAuth input boundary.
+
+Native Codex CLI can use the safe client accounting in `~/.codex/config.toml`:
+
+```toml
+model = "gpt-5.6-sol" # Or gpt-5.6-terra / gpt-5.6-luna.
+model_context_window = 921000
+model_auto_compact_token_limit = 828900
+# Optional; `total` is the default.
+model_auto_compact_token_limit_scope = "total"
+```
+
+The 828,900 limit is 90% of 921,000. These are native Codex CLI settings,
+separate from remora/Calico accounting; they do not raise OAuth entitlement or
+gateway configuration. CLIProxyAPI needs no context YAML edit or restart.
+
+The [Codex config reference](https://learn.chatgpt.com/docs/config-file/config-reference)
+defines profiles as `$CODEX_HOME/<name>.config.toml`, selected with
+`codex --profile <name>`. Keep the same context and compact keys in each profile:
+
+| Profile file | Model | Run with |
+| --- | --- | --- |
+| `$CODEX_HOME/sol.config.toml` | `gpt-5.6-sol` | `codex --profile sol` |
+| `$CODEX_HOME/terra.config.toml` | `gpt-5.6-terra` | `codex --profile terra` |
+| `$CODEX_HOME/luna.config.toml` | `gpt-5.6-luna` | `codex --profile luna` |
+
+Reusable profile template (set the row's model explicitly):
+
+```toml
+model = "gpt-5.6-sol"
+model_context_window = 921000
+model_auto_compact_token_limit = 828900
+model_auto_compact_token_limit_scope = "total"
 ```
 
 remora performs the lookup read-only, but its safe default follows stock Claude Code's 200K limit for unknown custom model ids. In `stock` mode it does not inject context or compact overrides; Claude's native output reserve and precompute policy remain authoritative. CLIProxyAPI needs no change or restart.
 
-The optional `calico` mode requires a verified Calico Claude binary. It takes the smaller value from the gateway catalog and a fresh local Codex runtime cache for every configured model, then passes that exact map into Calico's dormant adapter. The current 272K client window gives status-line consumers 258.4K usable context and begins compaction at 244.8K. A missing, older-than-five-minutes, or incomplete Codex cache falls back to 272K. A later fresh 372K runtime catalog restores 372K automatically. remora refuses to launch this mode if the binary does not contain the adapter marker.
+The optional `calico` mode requires a verified Calico Claude binary. It takes the smaller value from the gateway catalog and a fresh local Codex runtime cache for every configured model, then passes that exact map into Calico's dormant adapter. The current 272K client window gives status-line consumers 258.4K usable context and begins compaction at 244.8K. A missing, older-than-five-minutes, or incomplete Codex cache falls back to 272K. remora refuses to launch this mode if the binary does not contain the adapter marker. Native Codex CLI settings above are separate and do not change remora's smaller discovered `context_window` or `[context].auto_compact_percent` behavior.
 
 | Source | Meaning |
 |---|---|

--- a/docs/cliproxyapi.md
+++ b/docs/cliproxyapi.md
@@ -233,52 +233,42 @@ move the observed boundary. The official 1.05M total and 128K maximum-output
 facts are consistent context, but do not independently establish this exact
 OAuth input boundary.
 
-Native Codex CLI can use the safe client accounting in `~/.codex/config.toml`:
+| Evidence | All three exact GPT-5.6 slugs |
+|---|---:|
+| Official total context | 1,050,000 |
+| Largest accepted OAuth input | 921,858 |
+| First rejected OAuth input | 921,859 |
+| CLIProxyAPI `max_context_window` (2026-08-17) | 921,000 |
+| Fresh Codex cache `max_context_window` (2026-08-17 08:41 UTC) | 872,000 |
 
-```toml
-model = "gpt-5.6-sol" # Or gpt-5.6-terra / gpt-5.6-luna.
-model_context_window = 921000
-model_auto_compact_token_limit = 828900
-# Optional; `total` is the default.
-model_auto_compact_token_limit_scope = "total"
-```
+Remora reads this metadata read-only; it never writes native Codex or
+CLIProxyAPI configuration. In `calico` mode, `max_context_window` is considered
+only for the exact `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` slugs. It
+must be a positive non-bool integer; missing, null, boolean, string, zero, or
+negative values fall back to the existing `context_window` (and gateway
+`context_length`) fields. Other slugs keep their existing field semantics.
 
-The 828,900 limit is 90% of 921,000. These are native Codex CLI settings,
-separate from remora/Calico accounting; they do not raise OAuth entitlement or
-gateway configuration. CLIProxyAPI needs no context YAML edit or restart.
+Remora compares the gateway value with fresh Codex `models_cache` metadata for
+each configured model and uses the smaller value. With a 921,000 client window,
+the configured 90% compact ratio produces an 828,900 trigger. A missing, stale,
+or incomplete cache uses the configured fallback window instead. CLIProxyAPI
+needs no context YAML edit or restart.
 
-The [Codex config reference](https://learn.chatgpt.com/docs/config-file/config-reference)
-defines profiles as `$CODEX_HOME/<name>.config.toml`, selected with
-`codex --profile <name>`. Keep the same context and compact keys in each profile:
+remora's safe default follows stock Claude Code's 200K limit for unknown custom
+model ids. In `stock` mode it does not inject context or compact overrides;
+Claude's native output reserve and precompute policy remain authoritative.
 
-| Profile file | Model | Run with |
-| --- | --- | --- |
-| `$CODEX_HOME/sol.config.toml` | `gpt-5.6-sol` | `codex --profile sol` |
-| `$CODEX_HOME/terra.config.toml` | `gpt-5.6-terra` | `codex --profile terra` |
-| `$CODEX_HOME/luna.config.toml` | `gpt-5.6-luna` | `codex --profile luna` |
-
-Reusable profile template (set the row's model explicitly):
-
-```toml
-model = "gpt-5.6-sol"
-model_context_window = 921000
-model_auto_compact_token_limit = 828900
-model_auto_compact_token_limit_scope = "total"
-```
-
-remora performs the lookup read-only, but its safe default follows stock Claude Code's 200K limit for unknown custom model ids. In `stock` mode it does not inject context or compact overrides; Claude's native output reserve and precompute policy remain authoritative. CLIProxyAPI needs no change or restart.
-
-The optional `calico` mode requires a verified Calico Claude binary. It takes the smaller value from the gateway catalog and a fresh local Codex runtime cache for every configured model, then passes that exact map into Calico's dormant adapter. The current 272K client window gives status-line consumers 258.4K usable context and begins compaction at 244.8K. A missing, older-than-five-minutes, or incomplete Codex cache falls back to 272K. remora refuses to launch this mode if the binary does not contain the adapter marker. Native Codex CLI settings above are separate and do not change remora's smaller discovered `context_window` or `[context].auto_compact_percent` behavior.
+The optional `calico` mode requires a verified Calico Claude binary. It takes the smaller value from the gateway catalog and a fresh local Codex runtime cache for every configured model, then passes that exact map into Calico's dormant adapter. If both sources advertise 921K, the resulting client window is 921K, effective context is 874.95K, and the compact trigger is 828.9K. If the fresh cache advertises 872K, discovery intentionally caps the client at 872K. A missing, older-than-five-minutes, or incomplete Codex cache uses the configured fallback, which defaults to 272K. remora refuses to launch this mode if the binary does not contain the adapter marker. The discovered window is separate from OAuth entitlement and does not change remora's `[context].auto_compact_percent` behavior.
 
 | Source | Meaning |
 |---|---|
-| Gateway `context_window` | Gateway-advertised ceiling; retained for diagnostics |
-| Fresh `~/.codex/models_cache.json` | Authoritative Codex runtime ceiling; read-only, metadata only |
+| Gateway model metadata | `max_context_window` for the exact GPT-5.6 family; existing `context_window`/`context_length` otherwise |
+| Fresh Codex `models_cache` metadata | Authoritative Codex runtime ceiling; read-only, metadata only |
 | `[context].mode = "stock"` | Stock-safe 200K client behavior; default |
 | `[context].mode = "calico"` | Explicit opt-in to the verified custom-context adapter |
 | `[context].stock_window` | Stock Claude Code custom-model window, normally 200K |
 | `[context].fallback_window` | Conservative value used when catalog lookup is unavailable or incomplete |
-| `[context].codex_fallback_window` | Safe Codex ceiling when its runtime cache cannot be trusted; currently 272K |
+| `[context].codex_fallback_window` | Safe Codex ceiling when its runtime cache cannot be trusted; defaults to 272K |
 | `[context].codex_cache_ttl_seconds` | Freshness limit for the Codex runtime cache; matches Codex's 300-second TTL |
 | `[context].codex_models_cache` | Optional path override; otherwise uses `$CODEX_HOME/models_cache.json` or `~/.codex/models_cache.json` |
 | `[context].effective_window_percent` | Diagnostic effective-input ratio; Codex defaults to 95% |

--- a/docs/cliproxyapi.zh-TW.md
+++ b/docs/cliproxyapi.zh-TW.md
@@ -211,7 +211,13 @@ remora dry-run
 
 ## Context window 對齊
 
-不要把 OpenAI 公開 API 的 context 數字直接覆寫進 CLIProxyAPI metadata。公開 GPT-5.6 API 標示 1.05M，CLIProxyAPI 對 Codex OAuth route 目前則回報 372K。但 gateway 只是其中一層 ceiling；權威的 Codex runtime-catalog hot update 已在 2026-07-13 把 Sol、Terra、Luna 改成 272K。
+不要把 OpenAI 公開 API 的 context 數字直接覆寫進 CLIProxyAPI metadata。
+官方 [GPT-5.6-sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)、
+[GPT-5.6-terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra)、
+[GPT-5.6-luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna) 文件
+都標示 total context 1,050,000、maximum output 128,000。2026-08-17 的 live
+CLIProxyAPI catalog 中，三者都回傳 `context_window: 272000`、
+`max_context_window: 921000`、`auto_compact_token_limit: null`。
 
 Stock CLIProxyAPI 不需修改即可唯讀取得該值：
 
@@ -219,12 +225,55 @@ Stock CLIProxyAPI 不需修改即可唯讀取得該值：
 curl -fsS \
   -H "Authorization: Bearer $REMORA_AUTH_TOKEN" \
   'http://127.0.0.1:8317/v1/models?client_version=remora' \
-  | jq '.models[] | select(.slug | startswith("gpt-5.6-")) | {slug, context_window}'
+  | jq '.models[] | select(.slug | test("^gpt-5\\.6-(sol|terra|luna)$")) | {slug, context_window, max_context_window, auto_compact_token_limit}'
+```
+
+三個 slug 各自透過 Codex OAuth upstream 的直接 `/v1/responses` probe 都接受
+回報的 `usage.input_tokens=921,858`；緊鄰的 `921,859` 回傳
+`invalid_request_error`、code `context_too_large`。Payload calibration 測得
+固定 302-token translation overhead，因此 repeated-input count 是 921,556
+對 921,557。Luna 在回報 input 921,858 時，`max_output_tokens` 為 16、17、
+128、1000、128000 都接受，因此該參數沒有移動觀察到的邊界。官方 1.05M
+total 與 128K maximum output 是相符的背景事實，但不能單獨建立這個精確
+OAuth input boundary。
+
+原生 Codex CLI 可在 `~/.codex/config.toml` 使用安全的 client accounting：
+
+```toml
+model = "gpt-5.6-sol" # Or gpt-5.6-terra / gpt-5.6-luna.
+model_context_window = 921000
+model_auto_compact_token_limit = 828900
+# Optional；`total` 是預設值。
+model_auto_compact_token_limit_scope = "total"
+```
+
+828,900 limit 是 921,000 的 90%。這些是原生 Codex CLI 設定，與
+remora／Calico accounting 分開；不會提高 OAuth entitlement 或 gateway 設定。
+CLIProxyAPI 不需要修改 context YAML 或重啟。
+
+[Codex config reference](https://learn.chatgpt.com/docs/config-file/config-reference)
+定義 profile 位於 `$CODEX_HOME/<name>.config.toml`，並以
+`codex --profile <name>` 選用。每個 profile 都保留相同的 context 與 compact
+keys：
+
+| Profile 檔案 | Model | 啟動方式 |
+| --- | --- | --- |
+| `$CODEX_HOME/sol.config.toml` | `gpt-5.6-sol` | `codex --profile sol` |
+| `$CODEX_HOME/terra.config.toml` | `gpt-5.6-terra` | `codex --profile terra` |
+| `$CODEX_HOME/luna.config.toml` | `gpt-5.6-luna` | `codex --profile luna` |
+
+可重用的 profile template（明確設定該列 model）：
+
+```toml
+model = "gpt-5.6-sol"
+model_context_window = 921000
+model_auto_compact_token_limit = 828900
+model_auto_compact_token_limit_scope = "total"
 ```
 
 remora 會做同一個唯讀查詢，但安全預設遵循原生 Claude Code 對未知 custom model id 的 200K 上限。`stock` 模式不注入 context 或 compact override；Claude 原生的 output reserve 與 precompute policy 維持權威。CLIProxyAPI 不需要修改或重啟。
 
-可選的 `calico` 模式必須搭配通過驗證的 Calico Claude binary。remora 會針對每個已設定模型比較 gateway catalog 與新鮮的本機 Codex runtime cache，採用較小值後再把精確 map 交給 Calico 預設休眠的 adapter。目前 272K client window 會讓 statusline consumer 看到 258.4K usable context，並在 244.8K compact。Codex cache 不存在、超過五分鐘或不完整時，安全 fallback 也是 272K；若之後新鮮的 runtime catalog 回到 372K，remora 會自動恢復 372K。Binary 沒有 adapter marker 時，remora 會拒絕啟動該模式。
+可選的 `calico` 模式必須搭配通過驗證的 Calico Claude binary。remora 會針對每個已設定模型比較 gateway catalog 與新鮮的本機 Codex runtime cache，採用較小值後再把精確 map 交給 Calico 預設休眠的 adapter。目前 272K client window 會讓 statusline consumer 看到 258.4K usable context，並在 244.8K compact。Codex cache 不存在、超過五分鐘或不完整時，安全 fallback 也是 272K。Binary 沒有 adapter marker 時，remora 會拒絕啟動該模式。上述原生 Codex CLI 設定彼此分開，不會改變 remora 採用較小 `context_window` 或 `[context].auto_compact_percent` 的行為。
 
 | 來源 | 意義 |
 |---|---|

--- a/docs/cliproxyapi.zh-TW.md
+++ b/docs/cliproxyapi.zh-TW.md
@@ -190,7 +190,7 @@ export REMORA_AUTH_TOKEN='REPLACE_WITH_PROXY_API_KEY'
 remora doctor --online
 ```
 
-長期使用應改從 macOS Keychain 或其他 OS credential store 讀取，避免把 key 寫入 TOML、shell profile 或 repository。
+長期使用應改從 macOS Keychain 或其他 OS credential store 讀取，避免把 key 寫入 TOML、shell environment 或 repository。
 
 ## 模型設定
 
@@ -237,53 +237,41 @@ curl -fsS \
 total 與 128K maximum output 是相符的背景事實，但不能單獨建立這個精確
 OAuth input boundary。
 
-原生 Codex CLI 可在 `~/.codex/config.toml` 使用安全的 client accounting：
+| 證據 | 三個精確 GPT-5.6 slug |
+|---|---:|
+| 官方 total context | 1,050,000 |
+| OAuth 最大可接受 input | 921,858 |
+| OAuth 第一個拒絕的 input | 921,859 |
+| CLIProxyAPI `max_context_window`（2026-08-17） | 921,000 |
+| 新鮮 Codex cache `max_context_window`（2026-08-17 08:41 UTC） | 872,000 |
 
-```toml
-model = "gpt-5.6-sol" # Or gpt-5.6-terra / gpt-5.6-luna.
-model_context_window = 921000
-model_auto_compact_token_limit = 828900
-# Optional；`total` 是預設值。
-model_auto_compact_token_limit_scope = "total"
-```
+remora 只讀取這些 metadata；永遠不會寫入原生 Codex 或 CLIProxyAPI 設定。
+在 `calico` 模式，只有精確的 `gpt-5.6-sol`、`gpt-5.6-terra`、
+`gpt-5.6-luna` slug 才會使用 `max_context_window`。它必須是正的非 bool
+整數；缺少、null、boolean、string、零或負值，都會安全回退到既有的
+`context_window`（gateway 也支援 `context_length`）欄位。其他 slug 維持既有
+欄位語意。
 
-828,900 limit 是 921,000 的 90%。這些是原生 Codex CLI 設定，與
-remora／Calico accounting 分開；不會提高 OAuth entitlement 或 gateway 設定。
-CLIProxyAPI 不需要修改 context YAML 或重啟。
+remora 會針對每個已設定模型比較 gateway 值與新鮮的 Codex `models_cache`
+metadata，採用較小值。client window 為 921,000 時，設定的 90% compact ratio
+會推導出 828,900 trigger。cache 不存在、過期或不完整時，使用設定的 fallback
+window。CLIProxyAPI 不需要修改 context YAML 或重啟。
 
-[Codex config reference](https://learn.chatgpt.com/docs/config-file/config-reference)
-定義 profile 位於 `$CODEX_HOME/<name>.config.toml`，並以
-`codex --profile <name>` 選用。每個 profile 都保留相同的 context 與 compact
-keys：
+安全預設遵循原生 Claude Code 對未知 custom model id 的 200K 上限。`stock` 模式
+不注入 context 或 compact override；Claude 原生的 output reserve 與 precompute
+policy 維持權威。
 
-| Profile 檔案 | Model | 啟動方式 |
-| --- | --- | --- |
-| `$CODEX_HOME/sol.config.toml` | `gpt-5.6-sol` | `codex --profile sol` |
-| `$CODEX_HOME/terra.config.toml` | `gpt-5.6-terra` | `codex --profile terra` |
-| `$CODEX_HOME/luna.config.toml` | `gpt-5.6-luna` | `codex --profile luna` |
-
-可重用的 profile template（明確設定該列 model）：
-
-```toml
-model = "gpt-5.6-sol"
-model_context_window = 921000
-model_auto_compact_token_limit = 828900
-model_auto_compact_token_limit_scope = "total"
-```
-
-remora 會做同一個唯讀查詢，但安全預設遵循原生 Claude Code 對未知 custom model id 的 200K 上限。`stock` 模式不注入 context 或 compact override；Claude 原生的 output reserve 與 precompute policy 維持權威。CLIProxyAPI 不需要修改或重啟。
-
-可選的 `calico` 模式必須搭配通過驗證的 Calico Claude binary。remora 會針對每個已設定模型比較 gateway catalog 與新鮮的本機 Codex runtime cache，採用較小值後再把精確 map 交給 Calico 預設休眠的 adapter。目前 272K client window 會讓 statusline consumer 看到 258.4K usable context，並在 244.8K compact。Codex cache 不存在、超過五分鐘或不完整時，安全 fallback 也是 272K。Binary 沒有 adapter marker 時，remora 會拒絕啟動該模式。上述原生 Codex CLI 設定彼此分開，不會改變 remora 採用較小 `context_window` 或 `[context].auto_compact_percent` 的行為。
+可選的 `calico` 模式必須搭配通過驗證的 Calico Claude binary。remora 會針對每個已設定模型比較 gateway catalog 與新鮮的本機 Codex runtime cache，採用較小值後再把精確 map 交給 Calico 預設休眠的 adapter。兩個來源都宣告 921K 時，client window 為 921K、effective context 為 874.95K，並在 828.9K compact；若新鮮 cache 宣告 872K，discovery 會刻意把 client cap 在 872K。Codex cache 不存在、超過五分鐘或不完整時，使用設定的 fallback，預設為 272K。Binary 沒有 adapter marker 時，remora 會拒絕啟動該模式。這個 discovered window 與 OAuth entitlement 分開，不會改變 remora 採用的 `[context].auto_compact_percent` 行為。
 
 | 來源 | 意義 |
 |---|---|
-| Gateway `context_window` | Gateway 宣告的 ceiling；保留供診斷 |
-| 新鮮的 `~/.codex/models_cache.json` | 權威 Codex runtime ceiling；唯讀且只有 metadata |
+| Gateway model metadata | 精確 GPT-5.6 family 使用 `max_context_window`；其他情況使用既有 `context_window`／`context_length` |
+| 新鮮的 Codex `models_cache` metadata | 權威 Codex runtime ceiling；唯讀且只有 metadata |
 | `[context].mode = "stock"` | 原生安全的 200K client 行為；預設值 |
 | `[context].mode = "calico"` | 明確選用已驗證的 custom-context adapter |
 | `[context].stock_window` | 原生 Claude Code 的 custom-model window，通常是 200K |
 | `[context].fallback_window` | Catalog 查不到或不完整時的保守值 |
-| `[context].codex_fallback_window` | Runtime cache 不可信時的安全 Codex ceiling；目前為 272K |
+| `[context].codex_fallback_window` | Runtime cache 不可信時的安全 Codex ceiling；預設為 272K |
 | `[context].codex_cache_ttl_seconds` | Codex runtime cache 的 freshness 上限；對齊 Codex 的 300 秒 TTL |
 | `[context].codex_models_cache` | 可選的路徑 override；否則使用 `$CODEX_HOME/models_cache.json` 或 `~/.codex/models_cache.json` |
 | `[context].effective_window_percent` | 診斷用 effective-input 比例；Codex 預設 95% |

--- a/src/remora.py
+++ b/src/remora.py
@@ -38,6 +38,9 @@ DEFAULT_CODEX_CONTEXT_WINDOW = 272_000
 DEFAULT_CODEX_CACHE_TTL_SECONDS = 300
 DEFAULT_EFFECTIVE_CONTEXT_PERCENT = 95
 DEFAULT_AUTO_COMPACT_PERCENT = 90
+GPT56_LONG_CONTEXT_SLUGS = frozenset(
+    {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"}
+)
 AUTO_COMPACT_ENV = "CLAUDE_CODE_AUTO_COMPACT_WINDOW"
 AUTO_COMPACT_PERCENT_ENV = "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
 CLAUDE_EXTRA_BODY_ENV = "CLAUDE_CODE_EXTRA_BODY"
@@ -324,6 +327,24 @@ def routing_settings(config: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def select_model_context_window(row: dict[str, Any], *legacy_fields: str) -> int | None:
+    name = str(row.get("slug") or row.get("id") or "").strip()
+    if name in GPT56_LONG_CONTEXT_SLUGS:
+        fields = ("max_context_window", *legacy_fields)
+        for field in fields:
+            value = row.get(field)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                return value
+        return None
+
+    value = (
+        row.get(legacy_fields[0], row.get(legacy_fields[1]))
+        if len(legacy_fields) > 1
+        else row.get(legacy_fields[0])
+    )
+    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else None
+
+
 def fetch_gateway_context_windows(config: dict[str, Any], token: str) -> dict[str, int]:
     base_url = str(config["proxy"]["base_url"]).rstrip("/")
     query = urllib.parse.urlencode({"client_version": f"remora-{VERSION}"})
@@ -343,8 +364,8 @@ def fetch_gateway_context_windows(config: dict[str, Any], token: str) -> dict[st
         if not isinstance(row, dict):
             continue
         name = str(row.get("slug") or row.get("id") or "").strip()
-        value = row.get("context_window", row.get("context_length"))
-        if name and isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        value = select_model_context_window(row, "context_window", "context_length")
+        if name and value is not None:
             windows[name] = value
     return windows
 
@@ -401,8 +422,8 @@ def fetch_codex_context_windows(config: dict[str, Any]) -> dict[str, int]:
         if not isinstance(row, dict):
             continue
         name = str(row.get("slug") or row.get("id") or "").strip()
-        value = row.get("context_window")
-        if name and isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        value = select_model_context_window(row, "context_window")
+        if name and value is not None:
             windows[name] = value
     return windows
 

--- a/tests/test_remora.py
+++ b/tests/test_remora.py
@@ -1803,7 +1803,7 @@ class RemoraTests(unittest.TestCase):
         config = json.loads(json.dumps(self.config))
         config["context"]["mode"] = "calico"
         restored_windows = {
-            name: 372000 for name in remora.configured_model_names(config)
+            name: 921000 for name in remora.configured_model_names(config)
         }
         with (
             mock.patch.object(
@@ -1820,12 +1820,78 @@ class RemoraTests(unittest.TestCase):
             policy = remora.resolve_context_policy(
                 config, token="hidden", online=True
             )
-        self.assertEqual(policy["provider_window"], 372000)
-        self.assertEqual(policy["codex_window"], 372000)
-        self.assertEqual(policy["client_window"], 372000)
-        self.assertEqual(policy["effective_window"], 353400)
-        self.assertEqual(policy["compact_trigger"], 334800)
+        self.assertEqual(policy["provider_window"], 921000)
+        self.assertEqual(policy["codex_window"], 921000)
+        self.assertEqual(policy["client_window"], 921000)
+        self.assertEqual(policy["model_windows"], restored_windows)
+        self.assertEqual(policy["effective_window"], 874950)
+        self.assertEqual(policy["compact_trigger"], 828900)
         self.assertNotIn("capped to the Codex value", policy["warning"])
+
+    def test_context_metadata_prefers_gpt56_max_window_and_falls_back_safely(self) -> None:
+        family = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+        def gateway(rows: list[dict[str, object]]) -> dict[str, int]:
+            response = io.StringIO(json.dumps({"models": rows}))
+            with mock.patch.object(
+                remora.urllib.request, "urlopen", return_value=response
+            ):
+                return remora.fetch_gateway_context_windows(self.config, "hidden")
+
+        def cache(rows: list[dict[str, object]]) -> dict[str, int]:
+            with tempfile.TemporaryDirectory() as directory:
+                path = Path(directory) / "models_cache.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "fetched_at": remora.datetime.now(
+                                remora.timezone.utc
+                            ).isoformat(),
+                            "models": rows,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                config = json.loads(json.dumps(self.config))
+                config["context"]["codex_models_cache"] = str(path)
+                return remora.fetch_codex_context_windows(config)
+
+        rows = [
+            {"slug": name, "max_context_window": 921000, "context_window": 272000}
+            for name in family
+        ]
+        self.assertEqual(gateway(rows), dict.fromkeys(family, 921000))
+        self.assertEqual(cache(rows), dict.fromkeys(family, 921000))
+
+        for invalid in (None, True, "921000", 0, -1):
+            rows = [
+                {
+                    "slug": name,
+                    "max_context_window": invalid,
+                    "context_window": 272000,
+                }
+                for name in family
+            ]
+            self.assertEqual(gateway(rows), dict.fromkeys(family, 272000))
+            self.assertEqual(cache(rows), dict.fromkeys(family, 272000))
+
+        missing_max = [{"slug": name, "context_window": 272000} for name in family]
+        self.assertEqual(gateway(missing_max), dict.fromkeys(family, 272000))
+        self.assertEqual(cache(missing_max), dict.fromkeys(family, 272000))
+
+        context_length_only = [
+            {"slug": name, "context_length": 372000} for name in family
+        ]
+        self.assertEqual(gateway(context_length_only), dict.fromkeys(family, 372000))
+
+        rows = [
+            {
+                "slug": "other-model",
+                "max_context_window": 921000,
+                "context_window": 272000,
+            }
+        ]
+        self.assertEqual(gateway(rows), {"other-model": 272000})
+        self.assertEqual(cache(rows), {"other-model": 272000})
 
     def test_codex_context_cache_loader_rejects_stale_metadata(self) -> None:
         config = json.loads(json.dumps(self.config))


### PR DESCRIPTION
## Summary

- Prefer a valid `max_context_window` for the exact `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` slugs in both gateway and fresh Codex-cache metadata readers.
- Preserve legacy field fallbacks, source-minimum safety, cache freshness, warnings, and behavior for every other model.
- Document the measured Codex OAuth boundary and keep Remora read-only toward native Codex and CLIProxyAPI configuration.

## Runtime behavior

| Evidence | All three exact GPT-5.6 slugs |
|---|---:|
| Largest accepted OAuth input | 921,858 |
| First rejected OAuth input | 921,859 |
| CLIProxyAPI `max_context_window` snapshot | 921,000 |
| Fresh Codex cache snapshot | 872,000 |
| Remora when both metadata sources advertise 921K | 921,000; compact 828,900 |

Invalid or missing `max_context_window` values fall back to `context_window` and gateway `context_length`. A lower fresh source still caps discovery. Local Remora can independently use explicit 921K fallback configuration; this PR does not write Codex profiles or config.

## Validation

- `make check`: 97 unit tests plus installer, bootstrap, syntax, and CLI checks
- focused GPT-5.6 metadata edge matrix
- installed payload matched the tested worktree
- live discovery: gateway 921K, fresh cache 872K, safe client cap 872K
- local explicit Remora config: all three clients 921K, effective 874,950, compact 828,900, endpoint HTTP 200
- fresh outcome verifier: CONFIRMED
- staged tree: `5d3a07b84d9371760025816e5fb07ce388e62c27`